### PR TITLE
Updates both POSTs to explicitly declare Form Post

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,6 +31,7 @@ function connectDevice() {
 	$.ajax({
 		type: 'POST',
 		url: deviceAuthEndpoint,
+		contentType: "application/x-www-form-urlencoded; charset=UTF-8",
 		data: {
 			'client_id': clientId,
 			'scope': 'offline_access',
@@ -78,6 +79,7 @@ function pollForToken() {
 		$.ajax({
 			type: 'POST',
 			url: tokenEndpoint,
+			contentType: "application/x-www-form-urlencoded; charset=UTF-8",
 			data: {'device_code': deviceCode, 'grant_type': grantType, 'client_id': clientId},
 			datatype: 'json',
 			success: function(data) {


### PR DESCRIPTION
The AJAX `datatype` key threw me off when looking at this example as I had assumed that was the content type of the POST request, which it is not. AJAX POSTs are implicitly `application/x-www-form-urlencoded` which is an important thing to know as part of this flow. Making this explicit will hopefully avoid others from running into the same problem that I did. 

Full details @ [#639](https://github.com/FusionAuth/fusionauth-issues/issues/639).